### PR TITLE
Updating stateless and removing zkvm-ethereum-mpt dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "ef-tests"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=68cd8e73682d21fed69670fc7eabe25e55c5cdbe#68cd8e73682d21fed69670fc7eabe25e55c5cdbe"
+source = "git+https://github.com/paradigmxyz/stateless?rev=ed189a51931e8589102f3139d48fdbb3bbe4c1f7#ed189a51931e8589102f3139d48fdbb3bbe4c1f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2950,6 +2950,7 @@ dependencies = [
  "serde_json",
  "stateless",
  "thiserror 2.0.18",
+ "tries",
  "walkdir",
 ]
 
@@ -4089,7 +4090,7 @@ dependencies = [
  "serde_with",
  "stateless",
  "tiny-keccak",
- "zeth-mpt-state",
+ "tries",
 ]
 
 [[package]]
@@ -10797,15 +10798,13 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2F68cd8e73#0663f63729085bd4aa061be6e97f23d1109c371e"
+source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#f6b0b763be923dfd5334d6762bb51173afabad90"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
- "alloy-trie 0.9.5",
- "itertools 0.14.0",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-consensus",
@@ -10813,13 +10812,13 @@ dependencies = [
  "reth-evm",
  "reth-primitives-traits",
  "reth-trie-common",
- "reth-trie-sparse",
  "revm-bytecode",
  "revm-database-interface",
  "revm-state",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
+ "tries",
 ]
 
 [[package]]
@@ -11607,6 +11606,24 @@ checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
 dependencies = [
  "hash-db",
  "rlp 0.5.2",
+]
+
+[[package]]
+name = "tries"
+version = "0.1.0"
+source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#f6b0b763be923dfd5334d6762bb51173afabad90"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
+ "alloy-trie 0.9.5",
+ "itertools 0.14.0",
+ "reth-trie-common",
+ "reth-trie-sparse",
+ "revm-bytecode",
+ "revm-database-interface",
+ "thiserror 2.0.18",
+ "zeth-mpt",
 ]
 
 [[package]]
@@ -12741,7 +12758,7 @@ dependencies = [
 [[package]]
 name = "witness-generator"
 version = "0.1.0"
-source = "git+https://github.com/eth-act/zkevm-benchmark-workload.git?rev=a1f5dc47df7735500c1d8dfe055e966ee9f8070e#a1f5dc47df7735500c1d8dfe055e966ee9f8070e"
+source = "git+https://github.com/eth-act/zkevm-benchmark-workload.git?rev=63da9dde9b284dc4845cf7128c3f0d7c53d21654#63da9dde9b284dc4845cf7128c3f0d7c53d21654"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -12946,26 +12963,12 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.5.0#0e7ec8ecccf0d00ed1b7981155433e34b8746cc5"
+source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#f6b0b763be923dfd5334d6762bb51173afabad90"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.8.1",
  "arrayvec",
-]
-
-[[package]]
-name = "zeth-mpt-state"
-version = "0.1.0"
-source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.5.0#0e7ec8ecccf0d00ed1b7981155433e34b8746cc5"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie 0.9.5",
- "reth-trie-common",
- "revm-bytecode",
- "stateless",
- "zeth-mpt",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ zisk-sdk = { git = "https://github.com/0xPolygonHermez/zisk.git", branch = "pre-
 
 revm = { version = "34.0.0", default-features = false }
 
-# types (for ethrex)
-primitive-types = "0.13.1"
-ethereum-types = "0.15.1"
-
 # types (for reth)
 alloy-primitives = "1.5.6"
 alloy = "1.7.3"
@@ -41,21 +37,22 @@ reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = 
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
+stateless-reth = { git = "https://github.com/paradigmxyz/stateless", rev = "ed189a51931e8589102f3139d48fdbb3bbe4c1f7", package = "stateless" }
+stateless-reth-tries = { git = "https://github.com/paradigmxyz/stateless", rev = "ed189a51931e8589102f3139d48fdbb3bbe4c1f7", package = "tries" }
+
+# types (for ethrex)
+primitive-types = "0.13.1"
+ethereum-types = "0.15.1"
 
 # ethrex
 ethrex-config = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c1de67502f9ac49791c4a8efd654286a0b3b1bad" }
 ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c1de67502f9ac49791c4a8efd654286a0b3b1bad", default-features = false }
 ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c1de67502f9ac49791c4a8efd654286a0b3b1bad" }
 ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c1de67502f9ac49791c4a8efd654286a0b3b1bad", default-features = false }
-
-# stateless
-stateless-reth = { git = "https://github.com/paradigmxyz/stateless", rev = "68cd8e73682d21fed69670fc7eabe25e55c5cdbe", package = "stateless" }
 stateless-ethrex = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c1de67502f9ac49791c4a8efd654286a0b3b1bad", default-features = false, package = "ethrex-guest-program" }
 
-zeth-mpt-state = { git = "https://github.com/eth-act/zkvm-ethereum-mpt.git", tag = "v0.5.0" }
-
 # eth-act
-witness-generator = { git = "https://github.com/eth-act/zkevm-benchmark-workload.git", rev = "a1f5dc47df7735500c1d8dfe055e966ee9f8070e" }
+witness-generator = { git = "https://github.com/eth-act/zkevm-benchmark-workload.git", rev = "63da9dde9b284dc4845cf7128c3f0d7c53d21654" }
 
 # common dependencies
 anyhow = "1.0"
@@ -85,5 +82,7 @@ tempfile = "3"
 rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 
 [patch."https://github.com/paradigmxyz/stateless.git"]
-stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/68cd8e73" }
+stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
+tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
 # stateless = { path = "../zisk-patch-stateless/crates/stateless" }
+# tries = { path = "../zisk-patch-stateless/crates/tries" }

--- a/bin/guests/stateless-validator-reth/Cargo.lock
+++ b/bin/guests/stateless-validator-reth/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
  "serde_with",
  "stateless",
  "tiny-keccak",
- "zeth-mpt-state",
+ "tries",
 ]
 
 [[package]]
@@ -5149,15 +5149,13 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2F68cd8e73#0663f63729085bd4aa061be6e97f23d1109c371e"
+source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#f6b0b763be923dfd5334d6762bb51173afabad90"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
- "alloy-trie 0.9.5",
- "itertools 0.14.0",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-consensus",
@@ -5165,13 +5163,13 @@ dependencies = [
  "reth-evm",
  "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
  "reth-trie-common",
- "reth-trie-sparse",
  "revm-bytecode",
  "revm-database-interface",
  "revm-state",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
+ "tries",
 ]
 
 [[package]]
@@ -5611,6 +5609,24 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tries"
+version = "0.1.0"
+source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#f6b0b763be923dfd5334d6762bb51173afabad90"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
+ "alloy-trie 0.9.5",
+ "itertools 0.14.0",
+ "reth-trie-common",
+ "reth-trie-sparse",
+ "revm-bytecode",
+ "revm-database-interface",
+ "thiserror 2.0.18",
+ "zeth-mpt",
 ]
 
 [[package]]
@@ -6544,27 +6560,12 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-zkvm-ethereum-mpt.git?branch=zisk-hints%2Fv0.5.0#a1e3d24cb5b402b2b4ec03aa0101f631d98d19ba"
+source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#f6b0b763be923dfd5334d6762bb51173afabad90"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.8.1",
  "arrayvec",
-]
-
-[[package]]
-name = "zeth-mpt-state"
-version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-zkvm-ethereum-mpt.git?branch=zisk-hints%2Fv0.5.0#a1e3d24cb5b402b2b4ec03aa0101f631d98d19ba"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie 0.9.5",
- "itertools 0.14.0",
- "reth-trie-common",
- "revm-bytecode",
- "stateless",
- "zeth-mpt",
 ]
 
 [[package]]

--- a/bin/guests/stateless-validator-reth/Cargo.toml
+++ b/bin/guests/stateless-validator-reth/Cargo.toml
@@ -35,15 +35,12 @@ alloy-evm = { git = "https://github.com/0xPolygonHermez/zisk-patch-alloy-evm.git
 reth-trie-common = { git = "https://github.com/0xPolygonHermez/zisk-patch-reth.git", branch = "zisk-hints/v1.11.0" }
 # reth-trie-common = { path = "../../../zisk-patch-reth/crates/trie/common" }
 
-[patch."https://github.com/eth-act/zkvm-ethereum-mpt.git"]
-# Needed for deterministic Hashmap sort
-zeth-mpt-state = { git = "https://github.com/0xPolygonHermez/zisk-patch-zkvm-ethereum-mpt.git", branch = "zisk-hints/v0.5.0" }
-# zeth-mpt-state = { path = "../../../zisk-patch-zkvm-ethereum-mpt/crates/zeth-mpt-state" }
-
 [patch."https://github.com/paradigmxyz/stateless.git"]
-# Needed for function visibility
-stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/68cd8e73" }
+# Needed for function visibility and deterministic Hashmap sort
+stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
+tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
 # stateless = { path = "../zisk-patch-stateless/crates/stateless" }
+# tries = { path = "../zisk-patch-stateless/crates/tries" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zisk_hints)'] }

--- a/crates/guest-reth/Cargo.toml
+++ b/crates/guest-reth/Cargo.toml
@@ -27,7 +27,7 @@ reth-ethereum-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-evm-ethereum.workspace = true
 
-zeth-mpt-state.workspace = true
+stateless-reth-tries.workspace = true
 
 stateless-reth.workspace = true
 

--- a/crates/guest-reth/src/validation.rs
+++ b/crates/guest-reth/src/validation.rs
@@ -11,7 +11,7 @@ use stateless_reth::{
     recover_block_with_public_keys, stateless_validation_recovered_with_trie,
     validation::StatelessValidationError, UncompressedPublicKey,
 };
-use zeth_mpt_state::SparseState;
+use stateless_reth_tries::zeth::SparseState;
 
 /// Verifies transaction signatures against provided public keys.
 pub fn verify_signatures(


### PR DESCRIPTION
This pull request updates dependencies and refactors type imports to improve compatibility with the latest versions of the `stateless` and `tries` crates. The main focus is on replacing the `zeth-mpt-state` dependency with `stateless-reth-tries`, updating the relevant patch and import paths, and ensuring the codebase uses the new types provided by these crates.