### PR TITLE
Use U256 acceleration in reth client - dynamic dispatch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1547,7 +1547,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2013,7 +2013,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2517,7 +2517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2739,7 +2739,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3048,7 +3048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4408,7 +4408,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4428,7 +4428,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5814,7 +5814,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7344,7 +7344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7418,7 +7418,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7457,9 +7457,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7813,8 +7813,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "revm-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "tokio",
  "tokio-stream",
@@ -8781,9 +8781,9 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 22.1.0",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
@@ -8827,8 +8827,8 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
- "revm-state",
+ "revm-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum",
  "tokio",
  "tracing",
@@ -9070,7 +9070,7 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm-database",
+ "revm-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json",
 ]
 
@@ -9086,8 +9086,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
- "revm-state",
+ "revm-database-interface 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
 ]
 
@@ -9183,8 +9183,8 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "revm",
- "revm-interpreter",
- "revm-primitives",
+ "revm-interpreter 32.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 22.1.0",
  "rustc-hash 2.1.1",
  "schnellru",
  "serde",
@@ -9217,7 +9217,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
+ "revm-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "triehash",
 ]
@@ -9244,7 +9244,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database",
+ "revm-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_with",
 ]
@@ -9297,20 +9297,19 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 8.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
+ "revm-context-interface 14.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-database 10.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-database-interface 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "revm-handler",
  "revm-inspector",
- "revm-interpreter",
+ "revm-interpreter 32.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
 ]
 
 [[package]]
@@ -9321,24 +9320,34 @@ checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
 dependencies = [
  "bitvec",
  "phf",
- "revm-primitives",
+ "revm-primitives 22.1.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "8.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-context-interface 14.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-database-interface 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "serde",
 ]
 
@@ -9352,9 +9361,24 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 22.1.0",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "14.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "serde",
 ]
 
@@ -9365,10 +9389,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
 dependencies = [
  "alloy-eips",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 22.1.0",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "10.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode 8.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-database-interface 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "serde",
 ]
 
@@ -9380,8 +9417,21 @@ checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 22.1.0",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "9.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -9389,36 +9439,34 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 8.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
+ "revm-context-interface 14.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-database-interface 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-interpreter 32.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "serde",
 ]
 
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "auto_impl",
  "either",
  "revm-context",
- "revm-database-interface",
+ "revm-database-interface 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-interpreter 32.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "serde",
  "serde_json",
 ]
@@ -9447,18 +9495,29 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-context-interface 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 22.1.0",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "32.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "revm-bytecode 8.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-context-interface 14.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+version = "32.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -9472,10 +9531,22 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "22.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "ruint",
+ "serde",
 ]
 
 [[package]]
@@ -9498,8 +9569,20 @@ checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 22.1.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "9.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.11.0",
+ "revm-bytecode 8.0.0 (git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0)",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
@@ -9758,7 +9841,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9838,7 +9921,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10700,7 +10783,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#7735a599885082093c5462fbef462ed59c821f2b"
+source = "git+https://github.com/eth-act/zisk-patch-stateless.git?branch=feature%2Fswitchable-u256-backend#c26f35ec24d319f1cdc9697ede2366d88ab76390"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10714,9 +10797,9 @@ dependencies = [
  "reth-evm",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm-bytecode",
- "revm-database-interface",
- "revm-state",
+ "revm-bytecode 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -10923,7 +11006,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11513,7 +11596,7 @@ dependencies = [
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#7735a599885082093c5462fbef462ed59c821f2b"
+source = "git+https://github.com/eth-act/zisk-patch-stateless.git?branch=feature%2Fswitchable-u256-backend#c26f35ec24d319f1cdc9697ede2366d88ab76390"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11522,8 +11605,8 @@ dependencies = [
  "itertools 0.14.0",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-bytecode",
- "revm-database-interface",
+ "revm-bytecode 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
  "zeth-mpt",
 ]
@@ -12020,7 +12103,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12874,7 +12957,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#7735a599885082093c5462fbef462ed59c821f2b"
+source = "git+https://github.com/eth-act/zisk-patch-stateless.git?branch=feature%2Fswitchable-u256-backend#c26f35ec24d319f1cdc9697ede2366d88ab76390"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ http = "1.4.0"
 tempfile = "3"
 rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 
+[patch.crates-io]
+revm = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+
 [patch."https://github.com/paradigmxyz/stateless.git"]
 stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
 tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,5 @@ rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 revm = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
 
 [patch."https://github.com/paradigmxyz/stateless.git"]
-# Use local path to apply U256 type compatibility fixes
-stateless = { path = "../stateless/crates/stateless" }
-tries = { path = "../stateless/crates/tries" }
-# stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
-# tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
+stateless = { git = "https://github.com/eth-act/zisk-patch-stateless.git", branch = "feature/switchable-u256-backend" }
+tries = { git = "https://github.com/eth-act/zisk-patch-stateless.git", branch = "feature/switchable-u256-backend" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,8 @@ rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 revm = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
 
 [patch."https://github.com/paradigmxyz/stateless.git"]
-stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
-tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
-# stateless = { path = "../zisk-patch-stateless/crates/stateless" }
-# tries = { path = "../zisk-patch-stateless/crates/tries" }
+# Use local path to apply U256 type compatibility fixes
+stateless = { path = "../stateless/crates/stateless" }
+tries = { path = "../stateless/crates/tries" }
+# stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
+# tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }

--- a/bin/guests/stateless-validator-reth/Cargo.lock
+++ b/bin/guests/stateless-validator-reth/Cargo.lock
@@ -1386,7 +1386,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1978,7 +1978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4434,7 +4434,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4452,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "bitvec",
  "phf",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4479,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "auto_impl",
  "either",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "auto_impl",
  "either",
@@ -4555,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#a0440c06d98e7021c559f53c09d6281b95603bad"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -4759,7 +4759,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4818,7 +4818,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5370,7 +5370,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5968,7 +5968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bin/guests/stateless-validator-reth/Cargo.lock
+++ b/bin/guests/stateless-validator-reth/Cargo.lock
@@ -164,28 +164,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "auto_impl",
- "derive_more",
- "op-alloy",
- "op-revm",
- "revm",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-evm"
-version = "0.27.3"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-alloy-evm.git?branch=zisk-hints%2Fv0.27.3#f61d14215cb4d727d13a6b75d2f3f91595c0bf3e"
+source = "git+https://github.com/eth-act/zisk-patch-alloy-evm.git?branch=feature%2Fswitchable-u256-backend#a9062881a99d72cce69905421e4867df38eac4e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1142,7 +1121,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1379,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 
 [[package]]
 name = "clang-sys"
@@ -1407,7 +1386,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1999,7 +1978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2347,7 +2326,7 @@ dependencies = [
 name = "guest-common"
 version = "0.7.0"
 dependencies = [
- "zkvm-interface 0.17.0 (git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge)",
+ "zkvm-interface",
 ]
 
 [[package]]
@@ -2366,7 +2345,7 @@ dependencies = [
  "reth-chainspec",
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "revm",
  "serde",
  "serde_with",
@@ -2468,7 +2447,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2776,12 +2755,12 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib-c"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 
 [[package]]
 name = "lib-float"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 
 [[package]]
 name = "libc"
@@ -3527,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "precompiles-helpers"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3537,6 +3516,7 @@ dependencies = [
  "ark-std 0.5.0",
  "cfg-if",
  "circuit",
+ "crunchy",
  "lib-c",
  "num-bigint",
  "num-traits",
@@ -3814,7 +3794,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4019,12 +3999,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reth-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie 0.9.5",
@@ -4032,14 +4012,14 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-codecs"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4057,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4073,7 +4053,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "thiserror 2.0.18",
 ]
 
@@ -4086,18 +4066,18 @@ dependencies = [
  "alloy-eips",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-db-models"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "bytes",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "serde",
 ]
 
@@ -4113,14 +4093,14 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4133,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4142,7 +4122,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "reth-codecs",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "reth-zstd-compressors",
  "serde",
  "serde_with",
@@ -4151,21 +4131,21 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
  "futures-util",
  "rayon",
- "reth-execution-errors",
+ "reth-execution-errors 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
  "reth-execution-types",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "reth-storage-api",
- "reth-storage-errors",
+ "reth-storage-errors 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
  "reth-trie-common",
  "revm",
 ]
@@ -4173,11 +4153,11 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -4186,8 +4166,8 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
- "reth-storage-errors",
+ "reth-primitives-traits",
+ "reth-storage-errors 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
  "revm",
 ]
 
@@ -4196,26 +4176,39 @@ name = "reth-execution-errors"
 version = "1.11.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
 dependencies = [
- "alloy-evm 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles 0.4.8",
- "reth-storage-errors",
+ "reth-storage-errors 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-execution-errors"
+version = "1.11.0"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
+dependencies = [
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rlp",
+ "nybbles 0.4.8",
+ "reth-storage-errors 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-evm",
  "alloy-primitives",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "reth-trie-common",
  "revm",
  "serde",
@@ -4225,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4238,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4255,33 +4248,7 @@ dependencies = [
  "op-alloy-consensus",
  "reth-codecs",
  "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.11.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-reth.git?branch=zisk-hints%2Fv1.11.0#a068d98d78af4424847fa7fc2bb9d36bec101c0b"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie 0.9.5",
- "auto_impl",
- "bytes",
- "derive_more",
- "once_cell",
- "op-alloy-consensus",
- "revm-bytecode",
- "revm-primitives",
+ "revm-primitives 22.1.0",
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
@@ -4293,6 +4260,18 @@ dependencies = [
 name = "reth-prune-types"
 version = "1.11.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "strum",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-prune-types"
+version = "1.11.0"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4308,6 +4287,15 @@ version = "1.11.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
 dependencies = [
  "alloy-primitives",
+ "reth-trie-common",
+]
+
+[[package]]
+name = "reth-stages-types"
+version = "1.11.0"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
+dependencies = [
+ "alloy-primitives",
  "bytes",
  "reth-trie-common",
  "serde",
@@ -4321,7 +4309,20 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "fixed-map",
- "reth-stages-types",
+ "reth-stages-types 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "reth-static-file-types"
+version = "1.11.0"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "fixed-map",
+ "reth-stages-types 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
  "serde",
  "strum",
  "tracing",
@@ -4330,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4341,10 +4342,10 @@ dependencies = [
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
+ "reth-primitives-traits",
+ "reth-prune-types 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
+ "reth-stages-types 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
+ "reth-storage-errors 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
  "reth-trie-common",
  "revm-database",
  "serde_json",
@@ -4359,9 +4360,26 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
- "reth-prune-types",
- "reth-static-file-types",
+ "reth-primitives-traits",
+ "reth-prune-types 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-static-file-types 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "revm-database-interface",
+ "revm-state",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-storage-errors"
+version = "1.11.0"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "reth-primitives-traits",
+ "reth-prune-types 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
+ "reth-static-file-types 1.11.0 (git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend)",
  "revm-database-interface",
  "revm-state",
  "thiserror 2.0.18",
@@ -4370,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-reth.git?branch=zisk-hints%2Fv1.11.0#a068d98d78af4424847fa7fc2bb9d36bec101c0b"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4383,7 +4401,7 @@ dependencies = [
  "derive_more",
  "itertools 0.14.0",
  "nybbles 0.4.8",
- "reth-primitives-traits 1.11.0 (git+https://github.com/0xPolygonHermez/zisk-patch-reth.git?branch=zisk-hints%2Fv1.11.0)",
+ "reth-primitives-traits",
  "revm-database",
  "serde",
  "serde_with",
@@ -4398,8 +4416,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie 0.9.5",
  "auto_impl",
- "reth-execution-errors",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-execution-errors 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "reth-trie-common",
  "smallvec",
  "tracing",
@@ -4408,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/eth-act/zisk-patch-reth.git?branch=feature%2Fswitchable-u256-backend#4666de9b51b9994682bd0813d1bd6a26e8b104db"
 dependencies = [
  "zstd",
 ]
@@ -4416,8 +4434,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4428,27 +4445,25 @@ dependencies = [
  "revm-inspector",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
 ]
 
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "bitvec",
  "phf",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4456,7 +4471,7 @@ dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-database-interface",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
  "serde",
 ]
@@ -4464,15 +4479,14 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
  "revm-database-interface",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
  "serde",
 ]
@@ -4480,13 +4494,12 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
  "revm-database-interface",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
  "serde",
 ]
@@ -4494,12 +4507,11 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
  "serde",
  "thiserror 2.0.18",
@@ -4508,8 +4520,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4519,7 +4530,7 @@ dependencies = [
  "revm-database-interface",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
  "serde",
 ]
@@ -4527,8 +4538,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "auto_impl",
  "either",
@@ -4536,7 +4546,7 @@ dependencies = [
  "revm-database-interface",
  "revm-handler",
  "revm-interpreter",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
  "serde",
  "serde_json",
@@ -4545,21 +4555,19 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+version = "32.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4572,10 +4580,22 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "22.0.0"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "ruint",
+ "serde",
 ]
 
 [[package]]
@@ -4593,13 +4613,12 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+source = "git+https://github.com/eth-act/revm.git?branch=feature%2Fswitchable-u256-backend-v34.0.0#2c13a64fad8fc156b7fc0dc0e8baf3f6eca6b08b"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
  "revm-bytecode",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
@@ -4639,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "riscv"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 
 [[package]]
 name = "rlp"
@@ -4740,7 +4759,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4799,7 +4818,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5208,7 +5227,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#7735a599885082093c5462fbef462ed59c821f2b"
+source = "git+https://github.com/eth-act/zisk-patch-stateless.git?branch=feature%2Fswitchable-u256-backend#c26f35ec24d319f1cdc9697ede2366d88ab76390"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5220,7 +5239,7 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-primitives-traits 1.11.0 (git+https://github.com/paradigmxyz/reth?tag=v1.11.0)",
+ "reth-primitives-traits",
  "reth-trie-common",
  "revm-bytecode",
  "revm-database-interface",
@@ -5351,7 +5370,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5673,7 +5692,7 @@ dependencies = [
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#7735a599885082093c5462fbef462ed59c821f2b"
+source = "git+https://github.com/eth-act/zisk-patch-stateless.git?branch=feature%2Fswitchable-u256-backend#c26f35ec24d319f1cdc9697ede2366d88ab76390"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5949,7 +5968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5965,7 +5984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -5977,7 +5996,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5989,21 +6008,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6012,7 +6018,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6057,7 +6063,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6071,30 +6077,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6113,15 +6101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -6157,28 +6136,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6203,12 +6165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6219,12 +6175,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6239,22 +6189,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6269,12 +6207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6285,12 +6217,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6305,12 +6231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6321,12 +6241,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6524,7 +6438,7 @@ name = "zec-reth"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.27.3 (git+https://github.com/0xPolygonHermez/zisk-patch-alloy-evm.git?branch=zisk-hints%2Fv0.27.3)",
+ "alloy-evm",
  "alloy-primitives",
  "guest-reth",
  "revm",
@@ -6628,7 +6542,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-stateless.git?branch=zisk%2Fed189a5#7735a599885082093c5462fbef462ed59c821f2b"
+source = "git+https://github.com/eth-act/zisk-patch-stateless.git?branch=feature%2Fswitchable-u256-backend#c26f35ec24d319f1cdc9697ede2366d88ab76390"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6639,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "zisk-common"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6664,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "zisk-core"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 dependencies = [
  "elf",
  "fields",
@@ -6684,12 +6598,12 @@ dependencies = [
 [[package]]
 name = "zisk-definitions"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 
 [[package]]
 name = "zisk-verifier"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 dependencies = [
  "proofman-verifier",
 ]
@@ -6697,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "ziskos"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6723,13 +6637,13 @@ dependencies = [
  "zisk-common",
  "zisk-definitions",
  "zisk-verifier",
- "zkvm-interface 0.17.0 (git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0)",
+ "zkvm-interface",
 ]
 
 [[package]]
 name = "ziskos-hints"
 version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=ziskos-enlarge#d2a89eee1d01d60097f5bc80f83b0e6cc119e1fa"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6749,15 +6663,7 @@ dependencies = [
  "sha2",
  "tiny-keccak",
  "zisk-verifier",
- "zkvm-interface 0.17.0 (git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0)",
-]
-
-[[package]]
-name = "zkvm-interface"
-version = "0.17.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.17.0#42001a0448fcbfe9f459b2a2782b73f5e370f5cb"
-dependencies = [
- "bindgen 0.72.1",
+ "zkvm-interface",
 ]
 
 [[package]]

--- a/bin/guests/stateless-validator-reth/Cargo.toml
+++ b/bin/guests/stateless-validator-reth/Cargo.toml
@@ -27,7 +27,7 @@ alloy-primitives = { version = "1.5.6", features = ["native-keccak"] } # Needed 
 revm = { version = "34.0.0", default-features = false }
 
 # Needed for deterministic Hashmap sort + U256 type compatibility with revm fork
-alloy-evm = { path = "../../../../alloy-evm/crates/evm" }
+alloy-evm = { git = "https://github.com/eth-act/zisk-patch-alloy-evm.git", branch = "feature/switchable-u256-backend" }
 
 [patch.crates-io]
 revm = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
@@ -42,30 +42,27 @@ revm-primitives = { git = "https://github.com/eth-act/revm.git", branch = "featu
 revm-state = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
 revm-database-interface = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
 revm-context-interface = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
-alloy-evm = { path = "../../../../alloy-evm/crates/evm" }
+alloy-evm = { git = "https://github.com/eth-act/zisk-patch-alloy-evm.git", branch = "feature/switchable-u256-backend" }
 
 [patch."https://github.com/paradigmxyz/reth.git"]
 # Needed for deterministic Hashmap sort + U256 type compatibility with revm fork
-reth-trie-common = { path = "../../../../reth/crates/trie/common" }
-reth-primitives-traits = { path = "../../../../reth/crates/primitives-traits" }
-reth-execution-types = { path = "../../../../reth/crates/evm/execution-types" }
-reth-evm = { path = "../../../../reth/crates/evm/evm" }
-reth-evm-ethereum = { path = "../../../../reth/crates/ethereum/evm" }
-reth-ethereum-forks = { path = "../../../../reth/crates/ethereum/hardforks" }
-reth-chainspec = { path = "../../../../reth/crates/chainspec" }
-# Needed so serde feature unification works when reth-execution-types is patched locally
-reth-ethereum-primitives = { path = "../../../../reth/crates/ethereum/primitives" }
+reth-trie-common = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+reth-primitives-traits = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+reth-execution-types = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+reth-evm = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+reth-evm-ethereum = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+reth-ethereum-forks = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+reth-chainspec = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+# Needed so serde feature unification works when reth-execution-types is patched
+reth-ethereum-primitives = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
 
 [patch."https://github.com/0xPolygonHermez/zisk-patch-reth.git"]
-reth-primitives-traits = { path = "../../../../reth/crates/primitives-traits" }
-reth-ethereum-primitives = { path = "../../../../reth/crates/ethereum/primitives" }
+reth-primitives-traits = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
+reth-ethereum-primitives = { git = "https://github.com/eth-act/zisk-patch-reth.git", branch = "feature/switchable-u256-backend" }
 
 [patch."https://github.com/paradigmxyz/stateless.git"]
-# Use local path to apply U256 type compatibility fixes
-stateless = { path = "../../../../stateless/crates/stateless" }
-tries = { path = "../../../../stateless/crates/tries" }
-# stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
-# tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
+stateless = { git = "https://github.com/eth-act/zisk-patch-stateless.git", branch = "feature/switchable-u256-backend" }
+tries = { git = "https://github.com/eth-act/zisk-patch-stateless.git", branch = "feature/switchable-u256-backend" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zisk_hints)'] }

--- a/bin/guests/stateless-validator-reth/Cargo.toml
+++ b/bin/guests/stateless-validator-reth/Cargo.toml
@@ -15,7 +15,7 @@ panic = "abort"
 [dependencies]
 guest-reth = { path = "../../../crates/guest-reth" }
 
-ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git", branch = "pre-develop-0.17.0" }
+ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git", branch = "ziskos-enlarge" }
 # Local development
 # ziskos = { path = "../../../../zisk/ziskos/entrypoint" }
 
@@ -26,24 +26,46 @@ alloy-primitives = { version = "1.5.6", features = ["native-keccak"] } # Needed 
 # revm
 revm = { version = "34.0.0", default-features = false }
 
-# Needed for deterministic Hashmap sort
-alloy-evm = { git = "https://github.com/0xPolygonHermez/zisk-patch-alloy-evm.git", branch = "zisk-hints/v0.27.3" }
-# alloy-evm = { path = "../../../zisk-patch-alloy-evm/crates/evm" }
+# Needed for deterministic Hashmap sort + U256 type compatibility with revm fork
+alloy-evm = { path = "../../../../alloy-evm/crates/evm" }
 
 [patch.crates-io]
 revm = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-bytecode = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-context = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-database = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-handler = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-inspector = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-interpreter = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-precompile = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-primitives = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-state = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-database-interface = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+revm-context-interface = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+alloy-evm = { path = "../../../../alloy-evm/crates/evm" }
 
 [patch."https://github.com/paradigmxyz/reth.git"]
-# Needed for deterministic Hashmap sort
-reth-trie-common = { git = "https://github.com/0xPolygonHermez/zisk-patch-reth.git", branch = "zisk-hints/v1.11.0" }
-# reth-trie-common = { path = "../../../zisk-patch-reth/crates/trie/common" }
+# Needed for deterministic Hashmap sort + U256 type compatibility with revm fork
+reth-trie-common = { path = "../../../../reth/crates/trie/common" }
+reth-primitives-traits = { path = "../../../../reth/crates/primitives-traits" }
+reth-execution-types = { path = "../../../../reth/crates/evm/execution-types" }
+reth-evm = { path = "../../../../reth/crates/evm/evm" }
+reth-evm-ethereum = { path = "../../../../reth/crates/ethereum/evm" }
+reth-ethereum-forks = { path = "../../../../reth/crates/ethereum/hardforks" }
+reth-chainspec = { path = "../../../../reth/crates/chainspec" }
+# Needed so serde feature unification works when reth-execution-types is patched locally
+reth-ethereum-primitives = { path = "../../../../reth/crates/ethereum/primitives" }
+
+[patch."https://github.com/0xPolygonHermez/zisk-patch-reth.git"]
+reth-primitives-traits = { path = "../../../../reth/crates/primitives-traits" }
+reth-ethereum-primitives = { path = "../../../../reth/crates/ethereum/primitives" }
 
 [patch."https://github.com/paradigmxyz/stateless.git"]
-# Needed for function visibility and deterministic Hashmap sort
-stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
-tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
-# stateless = { path = "../zisk-patch-stateless/crates/stateless" }
-# tries = { path = "../zisk-patch-stateless/crates/tries" }
+# Use local path to apply U256 type compatibility fixes
+stateless = { path = "../../../../stateless/crates/stateless" }
+tries = { path = "../../../../stateless/crates/tries" }
+# stateless = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
+# tries = { git = "https://github.com/0xPolygonHermez/zisk-patch-stateless.git", branch = "zisk/ed189a5" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zisk_hints)'] }

--- a/bin/guests/stateless-validator-reth/Cargo.toml
+++ b/bin/guests/stateless-validator-reth/Cargo.toml
@@ -30,6 +30,9 @@ revm = { version = "34.0.0", default-features = false }
 alloy-evm = { git = "https://github.com/0xPolygonHermez/zisk-patch-alloy-evm.git", branch = "zisk-hints/v0.27.3" }
 # alloy-evm = { path = "../../../zisk-patch-alloy-evm/crates/evm" }
 
+[patch.crates-io]
+revm = { git = "https://github.com/eth-act/revm.git", branch = "feature/switchable-u256-backend-v34.0.0" }
+
 [patch."https://github.com/paradigmxyz/reth.git"]
 # Needed for deterministic Hashmap sort
 reth-trie-common = { git = "https://github.com/0xPolygonHermez/zisk-patch-reth.git", branch = "zisk-hints/v1.11.0" }

--- a/bin/guests/stateless-validator-reth/src/main.rs
+++ b/bin/guests/stateless-validator-reth/src/main.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use alloy_consensus::crypto::install_default_provider;
 use revm::install_crypto;
+use revm::primitives::install_uint256_backend;
 
 use guest_reth::{
     CustomEvmCrypto, RethInputPublic, RethInputWitness, extract_block_info, get_chain_name,
@@ -26,6 +27,9 @@ fn main() {
             panic!("Failed to init hints, error: {}", e);
         }
     }
+
+    // Install U256 backend.
+    install_uint256_backend(CustomEvmCrypto::default());
 
     // Install custom EVM crypto
     install_crypto(CustomEvmCrypto::default());

--- a/crates/guest-reth/src/crypto/impls.rs
+++ b/crates/guest-reth/src/crypto/impls.rs
@@ -9,6 +9,7 @@ use revm::precompile::{
     bls12_381::{G1Point, G1PointScalar, G2Point, G2PointScalar},
     Crypto, PrecompileError,
 };
+use revm::primitives::Uint256Ops;
 
 #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
 use guest_common::ffi::*;
@@ -794,6 +795,186 @@ impl Crypto for CustomEvmCrypto {
         #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
         {
             self.default_crypto.bls12_381_fp2_to_g2(fp2)
+        }
+    }
+}
+
+// Additional ZisK U256 accelerators not declared in zkvm_accelerators.h.
+// Declare them here so the linker can find them on the zkvm target.
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+extern "C" {
+    fn overflowing_mul256_c(a: *const u64, b: *const u64, result: *mut u64) -> u8;
+
+    fn overflowing_pow256_c(base: *const u64, exp: *const u64, result: *mut u64) -> u8;
+
+    fn checked_mul256_c(a: *const u64, b: *const u64, result: *mut u64) -> u8;
+
+    fn checked_div256_c(a: *const u64, b: *const u64, result: *mut u64) -> u8;
+
+    fn saturating_mul256_c(a: *const u64, b: *const u64, result: *mut u64);
+
+    fn wrapping_div256_c(a: *const u64, b: *const u64, result: *mut u64);
+
+    fn wrapping_rem256_c(a: *const u64, b: *const u64, result: *mut u64);
+}
+
+impl Uint256Ops for CustomEvmCrypto {
+    // TODO: Investigate
+    // fn overflowing_add(&self, a: [u64; 4], b: [u64; 4]) -> ([u64; 4], bool) {
+    //     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    //     {
+    //         let mut result = [0u64; 4];
+    //         let overflow =
+    //             unsafe { overflowing_add256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+    //         (result, overflow != 0)
+    //     }
+
+    //     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    //     {
+    //         self.native_uint256_ops.overflowing_add(a, b)
+    //     }
+    // }
+
+    // TODO: Investigate
+    // fn overflowing_sub(&self, a: [u64; 4], b: [u64; 4]) -> ([u64; 4], bool) {
+    //     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    //     {
+    //         let mut result = [0u64; 4];
+    //         let overflow =
+    //             unsafe { overflowing_sub256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+    //         (result, overflow != 0)
+    //     }
+
+    //     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    //     {
+    //         self.native_uint256_ops.overflowing_sub(a, b)
+    //     }
+    // }
+
+    fn overflowing_mul(&self, a: [u64; 4], b: [u64; 4]) -> ([u64; 4], bool) {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            let overflow =
+                unsafe { overflowing_mul256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return (result, overflow != 0);
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.overflowing_mul(a, b)
+        }
+    }
+
+    fn pow(&self, base: [u64; 4], exp: [u64; 4]) -> [u64; 4] {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            unsafe { overflowing_pow256_c(base.as_ptr(), exp.as_ptr(), result.as_mut_ptr()) };
+            return result;
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.pow(base, exp)
+        }
+    }
+
+    fn checked_mul(&self, a: [u64; 4], b: [u64; 4]) -> Option<[u64; 4]> {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            let success = unsafe { checked_mul256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return if success == 1 { Some(result) } else { None };
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.checked_mul(a, b)
+        }
+    }
+
+    fn checked_div(&self, a: [u64; 4], b: [u64; 4]) -> Option<[u64; 4]> {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            let success = unsafe { checked_div256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return if success == 1 { Some(result) } else { None };
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.checked_div(a, b)
+        }
+    }
+
+    fn saturating_mul(&self, a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            unsafe { saturating_mul256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return result;
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.saturating_mul(a, b)
+        }
+    }
+
+    fn wrapping_div(&self, a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            unsafe { wrapping_div256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return result;
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.wrapping_div(a, b)
+        }
+    }
+
+    fn wrapping_rem(&self, a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            unsafe { wrapping_rem256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return result;
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.wrapping_rem(a, b)
+        }
+    }
+
+    fn div(&self, a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            unsafe { wrapping_div256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return result;
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.div(a, b)
+        }
+    }
+
+    fn rem(&self, a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+        {
+            let mut result = [0u64; 4];
+            unsafe { wrapping_rem256_c(a.as_ptr(), b.as_ptr(), result.as_mut_ptr()) };
+            return result;
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+        {
+            self.native_uint256_ops.rem(a, b)
         }
     }
 }

--- a/crates/guest-reth/src/crypto/mod.rs
+++ b/crates/guest-reth/src/crypto/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
 use revm::precompile::DefaultCrypto;
+#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+use revm::primitives::DefaultUint256Ops;
 
 mod impls;
 
@@ -7,6 +9,8 @@ mod impls;
 pub struct CustomEvmCrypto {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     default_crypto: DefaultCrypto,
+    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    native_uint256_ops: DefaultUint256Ops,
 }
 
 impl Default for CustomEvmCrypto {
@@ -14,6 +18,8 @@ impl Default for CustomEvmCrypto {
         Self {
             #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
             default_crypto: DefaultCrypto,
+            #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+            native_uint256_ops: DefaultUint256Ops,
         }
     }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                       
                                                                  
This PR ports the ZisK U256 hardware accelerator support from the ethrex-based guest to the reth-based guest (bin/guests/stateless-validator-reth / crates/guest-reth), following the same pattern established in the ethrex
  implementation.                                                                                                                                                                                                               
   
What was done                                                                                                                                                                                                                                                                                
  - Implemented Uint256Ops for CustomEvmCrypto in crates/guest-reth/src/crypto/impls.rs, delegating the following operations to ZisK C FFI accelerators on zkvm targets:                                                        
    - overflowing_mul → overflowing_mul256_c
    - pow → overflowing_pow256_c                                                                                                                                                                                                
    - checked_mul → checked_mul256_c                                                                                                                                                                                            
    - checked_div → checked_div256_c
    - saturating_mul → saturating_mul256_c                                                                                                                                                                                      
    - wrapping_div / div → wrapping_div256_c                      
    - wrapping_rem / rem → wrapping_rem256_c                                                                                                                                                                                    
  - Called install_uint256_backend(CustomEvmCrypto::default()) in bin/guests/stateless-validator-reth/src/main.rs to register the backend with the revm fork at startup.
  - Switched ziskos dependency to branch ziskos-enlarge which exposes the U256 C FFI functions.                                                                                                                                 
                                                                  
  Non-zkvm builds fall back to DefaultUint256Ops (ruint) so native and hint-debug builds are unaffected.                                                                                                                        
                                                                       
---
## Patched upstream crates                                                                                                                                                                                                       
                                                                  
  The revm fork introduces a custom U256 newtype (with an injectable arithmetic backend) in place of the alloy_primitives::U256 type alias. This required compatibility fixes in several upstream crates. Each patch is a single
   commit on top of the existing ZisK fork branch.
                                                                                                                                                                                                                                
  Crate: revm                                                                                                                                                                                                        
  Fork: https://github.com/eth-act/revm/tree/feature/switchable-u256-backend-v34.0.0                                                                                                                                 
  Diff: https://github.com/eth-act/revm/compare/50405a27f57f80a96ab9d91e93180bca22217a3a..feature/switchable-u256-backend-v34.0.0                                                                                                                 
  ────────────────────────────────────────                                                                                                                                                                           
  Crate: alloy-evm                                                                                                                                                                                                   
  Fork: https://github.com/eth-act/zisk-patch-alloy-evm/tree/feature/switchable-u256-backend                                                                                                                                    
  Diff: https://github.com/eth-act/zisk-patch-alloy-evm/compare/zisk-hints/v0.27.3...feature/switchable-u256-backend                                                                                                            
  ────────────────────────────────────────                                                                                                                                                                                      
  Crate: reth (primitives-traits, trie-common, execution-types, evm, evm-ethereum, ethereum-forks, chainspec, ethereum-primitives)                                                                                              
  Fork: https://github.com/eth-act/zisk-patch-reth/tree/feature/switchable-u256-backend
  Diff: https://github.com/eth-act/zisk-patch-reth/compare/zisk-hints/v1.11.0...feature/switchable-u256-backend                                                                                                                 
  ────────────────────────────────────────                        
  Crate: stateless / tries                                                                                                                                                                                                      
  Fork: https://github.com/eth-act/zisk-patch-stateless/tree/feature/switchable-u256-backend
  Diff: https://github.com/eth-act/zisk-patch-stateless/compare/zisk/ed189a5...feature/switchable-u256-backend                                                                                                                  

---
                                               
## Testing

  All three required builds pass, and all 9 mainnet block test inputs execute correctly:                                                                                                                                        
   
  RUSTFLAGS='--cfg zisk_hints --cfg zisk_hints_debug' cargo build --release                                                                                                                                               
  cargo build --release
  cargo-zisk build --release
